### PR TITLE
Add AssumeNoStringOverflow

### DIFF
--- a/prims.go
+++ b/prims.go
@@ -126,3 +126,9 @@ func TimeNow() uint64 {
 func Sleep(ns uint64) {
 	time.Sleep(time.Duration(ns) * time.Nanosecond)
 }
+
+// AssumeNoStringOverflow is modeled as an assumption that the length of `s` is
+// less than 2^64.
+//
+// This is an invariant of the Go runtime so we do nothing here.
+func AssumeNoStringOverflow(s string) {}


### PR DESCRIPTION
Code does nothing, model will assume string length is < 2^64. The spec is:

```
Lemma wp_AssumeNoStringOverflow (s: byte_string) :
  {{{ is_pkg_init primitive }}}
    primitive@"AssumeNoStringOverflow" #s
  {{{ RET #(); ⌜Z.of_nat (length s) < 2^64⌝ }}}.
```